### PR TITLE
Make retina more future-proof

### DIFF
--- a/_settings.responsive.scss
+++ b/_settings.responsive.scss
@@ -13,7 +13,7 @@ $breakpoints: (
     "lap-and-up"    "screen and (min-width: 45em)",
     "portable"      "screen and (max-width: 63.9375em)",
     "desk"          "screen and (min-width: 64em)",
-    "retina"        "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"
+    "retina"        "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)"
 ) !default;
 
 


### PR DESCRIPTION
As per https://css-tricks.com/snippets/css/retina-display-media-query/
and to avoid the message in the console in Chrome:
> Consider using 'dppx' units, as in CSS 'dpi' means dots-per-CSS-inch, not dots-per-physical-inch, so does not correspond to the actual 'dpi' of a screen. In media query expression: (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)